### PR TITLE
Add TempoROS Conversion and Common Converters

### DIFF
--- a/Source/TempoROS/Public/TempoROSCommonConverters.h
+++ b/Source/TempoROS/Public/TempoROSCommonConverters.h
@@ -11,7 +11,10 @@
 #include "rclcpp/time.hpp"
 
 DEFINE_TEMPOROS_MESSAGE_TYPE_TRAITS(FString)
+DEFINE_TEMPOROS_MESSAGE_TYPE_TRAITS(FVector)
+DEFINE_TEMPOROS_MESSAGE_TYPE_TRAITS(FRotator)
 DEFINE_TEMPOROS_MESSAGE_TYPE_TRAITS(FTransform)
+DEFINE_TEMPOROS_MESSAGE_TYPE_TRAITS(FTwist)
 
 template <>
 struct TToROSConverter<std::string, FString> : TConverter<TToROSConverter<std::string, FString>>
@@ -93,6 +96,9 @@ struct TImplicitFromROSConverter<FVector> : TFromROSConverter<geometry_msgs::msg
 		return ToType(100.0 * ROSVector.x, -100.0 * ROSVector.y, 100.0 * ROSVector.z);
 	}
 };
+
+// Helpful link explaining conversion of quaternion between left and right-handed coordinates
+// https://gamedev.stackexchange.com/questions/157946/converting-a-quaternion-in-a-right-to-left-handed-coordinate-system
 
 template <>
 struct TToROSConverter<geometry_msgs::msg::Quaternion, FQuat> : TConverter<TToROSConverter<geometry_msgs::msg::Quaternion, FQuat>>

--- a/Source/TempoROS/Public/TempoROSConversion.h
+++ b/Source/TempoROS/Public/TempoROSConversion.h
@@ -14,6 +14,7 @@ template <> inline FName TMessageTypeTraits<MessageType>::MessageTypeDescriptor 
 template <typename T>
 struct TConverter
 {
+	// From kennytm's answer here: https://stackoverflow.com/questions/8113878/c-crtp-and-accessing-deriveds-nested-typedefs-from-base
 	template <typename X = T>
 	using ToType = typename X::ToType;
 


### PR DESCRIPTION
Adds templated "converters" to improve code clarity and sharing when publishing or subscribing non-ROS types over ROS. 

`TConverter`is a generic converter with a base `Convert` that does no conversion (but asserts that the To and From types are the same)

`TToROSConverter` and `TFromROSConverter` define a `Convert` that converts to or from a Tempo/Unreal type to/from a ROS type.

`TImplicitToROSConverter` and `TImplicitFromROSConverter` associate a Tempo/Unreal type with a specific ROS type, improving code brevity where this association is known,

Also adds some common converters, which also serve as good examples of how to write converters.