### PR TITLE
Include ROS share Directory in Packaged Game

### DIFF
--- a/Source/TempoROS/Private/TempoROS.cpp
+++ b/Source/TempoROS/Private/TempoROS.cpp
@@ -21,13 +21,22 @@ void SetAmentPrefixPath()
 	const FString ProjectPath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*FPaths::ProjectDir());
 	TArray<FString> PossibleTargets;
 #if WITH_EDITOR
+	// With the Editor we simply look for the Build.cs file
 	IFileManager::Get().FindFilesRecursive(PossibleTargets, *ProjectPath, TEXT("rclcpp.Build.cs"), true, false);
 	for (FString& PossibleTarget : PossibleTargets)
 	{
 		PossibleTarget = FPaths::GetPath(PossibleTarget);
 	}
 #else
+	// In the packaged game we search for a directory called "rclcpp" within a directory called "ThirdParty" 
 	IFileManager::Get().FindFilesRecursive(PossibleTargets, *ProjectPath, TEXT("rclcpp"), false, true);
+	for (auto PossibleTargetIt = PossibleTargets.CreateIterator(); PossibleTargetIt; ++PossibleTargetIt)
+	{
+		if (!FPaths::GetPath(*PossibleTargetIt).EndsWith(TEXT("ThirdParty")))
+		{
+			PossibleTargetIt.RemoveCurrent();
+		}
+	}
 #endif
 	checkf(PossibleTargets.Num() == 1, TEXT("Expected to find exactly one rclcpp module"));
 	const FString rclcppDir = PossibleTargets[0];

--- a/Source/ThirdParty/rclcpp/rclcpp.Build.cs
+++ b/Source/ThirdParty/rclcpp/rclcpp.Build.cs
@@ -40,16 +40,19 @@ public class rclcpp : ModuleRules
             // TODO: Is this correct on Windows?
             LibraryPaths.AddRange(FindFilesInDirectory(Path.Combine(ModuleDirectory, "Libraries", "Windows"), "dll"));
             RuntimeLibraryPaths.AddRange(FindFilesInDirectory(Path.Combine(ModuleDirectory, "Libraries", "Windows"), "dll"));
+            RuntimeLibraryPaths.AddRange(FindFilesInDirectory(Path.Combine(ModuleDirectory, "Libraries", "Windows", "share"), "*"));
         }
         else if (Target.Platform == UnrealTargetPlatform.Mac)
         {
             LibraryPaths.AddRange(FindFilesInDirectory(Path.Combine(ModuleDirectory, "Libraries", "Mac"), "dylib"));
             RuntimeLibraryPaths.AddRange(FindFilesInDirectory(Path.Combine(ModuleDirectory, "Libraries", "Mac"), "dylib"));
+            RuntimeLibraryPaths.AddRange(FindFilesInDirectory(Path.Combine(ModuleDirectory, "Libraries", "Mac", "share"), "*"));
         }
         else if (Target.Platform == UnrealTargetPlatform.Linux)
         {
             LibraryPaths.AddRange(FindFilesInDirectory(Path.Combine(ModuleDirectory, "Libraries", "Linux"), "so"));
             RuntimeLibraryPaths.AddRange(FindFilesInDirectory(Path.Combine(ModuleDirectory, "Libraries", "Linux"), "so*"));
+            RuntimeLibraryPaths.AddRange(FindFilesInDirectory(Path.Combine(ModuleDirectory, "Libraries", "Linux", "share"), "*"));
         }
         else
         {


### PR DESCRIPTION
ROS uses information from the `share` folder to load plugins are runtime, so we need to include that in the packaged game.