### PR TITLE
Remove netrc Requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This plugin was written by Tempo Simulation, LLC, and is free for anyone to use 
 
 If you enable `TempoROS` in a project where you **are** using the other Tempo plugins you should also enable `TempoROSBridge`.
 
+`TempoROS` currently only supports Linux. Windows and Mac support will come very soon.
+
 > [!Note]
 > `TempoROS`, like `TempoScripting`, includes a pre-build code generation step for ROS IDL files in your project. If you're not changing ROS IDL files, and you've built at least once, you can use the `TEMPO_SKIP_PREBUILD` environment variable to skip this step. Note that you may have to restart your IDE after changing this.
 

--- a/Scripts/SyncDeps.sh
+++ b/Scripts/SyncDeps.sh
@@ -6,6 +6,11 @@
 
 set -e
 
+if [[ "$OSTYPE" != "linux-gnu"* ]]; then
+  echo "TempoROS only supports Linux right now. Come back soon!"
+  exit 1
+fi
+
 # Check for jq
 if ! which jq &> /dev/null; then
   echo "Couldn't find jq"


### PR DESCRIPTION
After converting `TempoThirdParty` to a public repo, users will not need a `netrc` file to authenticate requests.

Also, indicate that Windows and Mac are not yet supported.