### PR TITLE
Wrap rclcpp Calls in Try/Catch

### DIFF
--- a/Scripts/GenROSBP.sh
+++ b/Scripts/GenROSBP.sh
@@ -66,24 +66,24 @@ if [[ "$OSTYPE" = "msys" ]]; then
 BP_PUBLISHER_TEMPLATE=\
 '
     UFUNCTION(BlueprintCallable, Category = "TempoROS", meta=(AutoCreateRefTerm="QOSProfile"))
-    static void Add__SANITIZEDMESSAGETYPE__Publisher(UTempoROSNode* Node, const FString\& Topic, const FROSQOSProfile\& QOSProfile=FROSQOSProfile(), bool bPrependNodeName=true)
+    static bool Add__SANITIZEDMESSAGETYPE__Publisher(UTempoROSNode* Node, const FString\& Topic, const FROSQOSProfile\& QOSProfile=FROSQOSProfile(), bool bPrependNodeName=true)
     {
-        Node->AddPublisher<__MESSAGETYPE__>(Topic, QOSProfile, bPrependNodeName);
+        return Node->AddPublisher<__MESSAGETYPE__>(Topic, QOSProfile, bPrependNodeName);
     }
 
     UFUNCTION(BlueprintCallable, Category = "TempoROS")
-    static void Publish__SANITIZEDMESSAGETYPE__(UTempoROSNode* Node, const FString\& Topic, const __MESSAGETYPE__\& Message)
+    static bool Publish__SANITIZEDMESSAGETYPE__(UTempoROSNode* Node, const FString\& Topic, const __MESSAGETYPE__\& Message)
     {
-        Node->Publish<__MESSAGETYPE__>(Topic, Message);
+        return Node->Publish<__MESSAGETYPE__>(Topic, Message);
     }
 '
   
 BP_SUBSCRIPTION_TEMPLATE=\
 '
     UFUNCTION(BlueprintCallable, Category = "TempoROS")
-    static void Add__SANITIZEDMESSAGETYPE__Subscription(UTempoROSNode* Node, const FString\& Topic, const FTempoROS__SANITIZEDMESSAGETYPE__Received\& TempoROSMessageReceivedEvent)
+    static bool Add__SANITIZEDMESSAGETYPE__Subscription(UTempoROSNode* Node, const FString\& Topic, const FTempoROS__SANITIZEDMESSAGETYPE__Received\& TempoROSMessageReceivedEvent)
     {
-        Node->AddSubscription<__MESSAGETYPE__>(Topic, TROSSubscriptionDelegate<__MESSAGETYPE__>::CreateLambda([TempoROSMessageReceivedEvent](const __MESSAGETYPE__\& Value)
+        return Node->AddSubscription<__MESSAGETYPE__>(Topic, TROSSubscriptionDelegate<__MESSAGETYPE__>::CreateLambda([TempoROSMessageReceivedEvent](const __MESSAGETYPE__\& Value)
         {
             TempoROSMessageReceivedEvent.ExecuteIfBound(Value);
         }));
@@ -93,24 +93,24 @@ else
 BP_PUBLISHER_TEMPLATE=\
 '
     UFUNCTION(BlueprintCallable, Category = "TempoROS", meta=(AutoCreateRefTerm="QOSProfile"))
-    static void Add__SANITIZEDMESSAGETYPE__Publisher(UTempoROSNode* Node, const FString& Topic, const FROSQOSProfile& QOSProfile=FROSQOSProfile(), bool bPrependNodeName=true)
+    static bool Add__SANITIZEDMESSAGETYPE__Publisher(UTempoROSNode* Node, const FString& Topic, const FROSQOSProfile& QOSProfile=FROSQOSProfile(), bool bPrependNodeName=true)
     {
-        Node->AddPublisher<__MESSAGETYPE__>(Topic, QOSProfile, bPrependNodeName);
+        return Node->AddPublisher<__MESSAGETYPE__>(Topic, QOSProfile, bPrependNodeName);
     }
 
     UFUNCTION(BlueprintCallable, Category = "TempoROS")
-    static void Publish__SANITIZEDMESSAGETYPE__(UTempoROSNode* Node, const FString& Topic, const __MESSAGETYPE__& Message)
+    static bool Publish__SANITIZEDMESSAGETYPE__(UTempoROSNode* Node, const FString& Topic, const __MESSAGETYPE__& Message)
     {
-        Node->Publish<__MESSAGETYPE__>(Topic, Message);
+        return Node->Publish<__MESSAGETYPE__>(Topic, Message);
     }
 '
   
 BP_SUBSCRIPTION_TEMPLATE=\
 '
     UFUNCTION(BlueprintCallable, Category = "TempoROS")
-    static void Add__SANITIZEDMESSAGETYPE__Subscription(UTempoROSNode* Node, const FString& Topic, const FTempoROS__SANITIZEDMESSAGETYPE__Received& TempoROSMessageReceivedEvent)
+    static bool Add__SANITIZEDMESSAGETYPE__Subscription(UTempoROSNode* Node, const FString& Topic, const FTempoROS__SANITIZEDMESSAGETYPE__Received& TempoROSMessageReceivedEvent)
     {
-        Node->AddSubscription<__MESSAGETYPE__>(Topic, TROSSubscriptionDelegate<__MESSAGETYPE__>::CreateLambda([TempoROSMessageReceivedEvent](const __MESSAGETYPE__& Value)
+        return Node->AddSubscription<__MESSAGETYPE__>(Topic, TROSSubscriptionDelegate<__MESSAGETYPE__>::CreateLambda([TempoROSMessageReceivedEvent](const __MESSAGETYPE__& Value)
         {
             TempoROSMessageReceivedEvent.ExecuteIfBound(Value);
         }));

--- a/Source/TempoROS/Private/TempoROS.cpp
+++ b/Source/TempoROS/Private/TempoROS.cpp
@@ -117,8 +117,15 @@ void FTempoROSModule::InitROS()
 	// ROS_DOMAIN_ID
 	FPlatformMisc::SetEnvironmentVar(TEXT("ROS_DOMAIN_ID"), *FString::FromInt(TempoROSSettings->GetROSDomainID()));
 
-	rclcpp::init(0, nullptr);
-	
+	try
+	{
+		rclcpp::init(0, nullptr);
+	}
+	catch (const std::exception& E)
+	{
+		UE_LOG(LogTempoROS, Error, TEXT("Failed to initialize rclcpp with error: %s"), UTF8_TO_TCHAR(E.what()));
+	}
+
 	bROSInitialized = true;
 }
 
@@ -126,8 +133,15 @@ void FTempoROSModule::ShutdownROS()
 {
 	if (bROSInitialized)
 	{
-		rclcpp::shutdown();
-	
+		try
+		{
+			rclcpp::shutdown();
+		}
+		catch (const std::exception& E)
+		{
+			UE_LOG(LogTempoROS, Error, TEXT("Failed to shut down rclcpp with error: %s"), UTF8_TO_TCHAR(E.what()));
+		}
+
 		bROSInitialized = false;
 	}
 	else

--- a/Source/TempoROS/Private/TempoROSNode.cpp
+++ b/Source/TempoROS/Private/TempoROSNode.cpp
@@ -22,7 +22,6 @@ UTempoROSNode* UTempoROSNode::Create(const FString& NodeName, UObject* Outer, bo
 			UE_LOG(LogTempoROS, Error, TEXT("Unable to find world to auto tick TempoROS node %s"), *NodeName);
 		}
 	}
-	// TODO: Wrap all rclcpp calls in try/catch
 	try
 	{
 		NewNode->Init(NodeName, NodeOptions, TickWithWorld);

--- a/Source/TempoROS/Private/TempoROSNode.cpp
+++ b/Source/TempoROS/Private/TempoROSNode.cpp
@@ -28,7 +28,7 @@ UTempoROSNode* UTempoROSNode::Create(const FString& NodeName, UObject* Outer, bo
 	}
 	catch (const std::exception& Exception)
 	{
-		UE_LOG(LogTempoROS, Error, TEXT("Failed to initialize node. Error: %hs"), Exception.what());
+		UE_LOG(LogTempoROS, Error, TEXT("Failed to initialize node. Error: %s"), UTF8_TO_TCHAR(Exception.what()));
 	}
 	return NewNode;
 }

--- a/Source/TempoROS/Public/TempoROSNode.h
+++ b/Source/TempoROS/Public/TempoROSNode.h
@@ -210,7 +210,7 @@ public:
 		}
 		try
 		{
-			Transform = TFListener->GetTransform(FromFrameResolved, ToFrame, Timestamp);
+			return TFListener->GetTransform(FromFrameResolved, ToFrame, Timestamp, Transform);
 		}
 		catch (const std::exception& E)
 		{

--- a/Source/TempoROS/Public/TempoROSNode.h
+++ b/Source/TempoROS/Public/TempoROSNode.h
@@ -42,72 +42,112 @@ public:
 	TSet<FString> GetPublishedTopics() const;
 	
 	template <typename MessageType>
-	void AddPublisher(const FString& Topic, const FROSQOSProfile& QOSProfile=FROSQOSProfile(), bool bPrependNodeName=true)
+	bool AddPublisher(const FString& Topic, const FROSQOSProfile& QOSProfile=FROSQOSProfile(), bool bPrependNodeName=true)
 	{
 		if (TMessageTypeTraits<MessageType>::MessageTypeDescriptor == NAME_None)
 		{
 			UE_LOG(LogTempoROS, Error, TEXT("Attempted to create a publisher for a type with missing type traits. Use DEFINE_TEMPOROS_MESSAGE_TYPE_TRAITS to define."));
-			return;
+			return false;
 		}
 		if (Publishers.Contains(Topic))
 		{
 			UE_LOG(LogTempoROS, Error, TEXT("Node already has publisher for topic %s"), *Topic);
-			return;
+			return false;
 		}
-		Publishers.Emplace(Topic, MakeUnique<TTempoROSPublisher<MessageType>>(this, Topic, QOSProfile, bPrependNodeName));
+		try
+		{
+			Publishers.Emplace(Topic, MakeUnique<TTempoROSPublisher<MessageType>>(this, Topic, QOSProfile, bPrependNodeName));
+		}
+		catch (const std::exception& E)
+		{
+			UE_LOG(LogTempoROS, Error, TEXT("Failed to create publisher for topic %s with error: %s"), *Topic, UTF8_TO_TCHAR(E.what()));
+			return false;
+		}
+		return true;
 	}
 
 	UFUNCTION(BlueprintCallable)
 	void RemovePublisher(const FString& Topic);
 
 	template <typename MessageType>
-	void Publish(const FString& Topic, const MessageType& Message)
+	bool Publish(const FString& Topic, const MessageType& Message)
 	{
 		TUniquePtr<FTempoROSPublisher>* PublisherPtr = Publishers.Find(Topic);
 		if (!PublisherPtr)
 		{
-			PublisherPtr = &Publishers.Emplace(Topic, MakeUnique<TTempoROSPublisher<MessageType>>(this, Topic, FROSQOSProfile(), true));
+			try
+			{
+				PublisherPtr = &Publishers.Emplace(Topic, MakeUnique<TTempoROSPublisher<MessageType>>(this, Topic, FROSQOSProfile(), true));
+			}
+			catch (const std::exception& E)
+			{
+				UE_LOG(LogTempoROS, Error, TEXT("Failed to create publisher for topic %s with error: %s"), *Topic, UTF8_TO_TCHAR(E.what()));
+				return false;
+			}
 		}
-		if (const TTempoROSPublisher<MessageType>* TypedPublisher = Cast<MessageType>(PublisherPtr->Get()))
+		const TTempoROSPublisher<MessageType>* TypedPublisher = Cast<MessageType>(PublisherPtr->Get());
+		if (!TypedPublisher)
 		{
-			TypedPublisher->Publish(Message);
-			return;
+			UE_LOG(LogTempoROS, Error, TEXT("Publisher for topic %s did not have correct type"), *Topic);
+			return false;
 		}
-		UE_LOG(LogTempoROS, Error, TEXT("Publisher for topic %s did not have correct type"), *Topic);
+		{
+			try
+			{
+				TypedPublisher->Publish(Message);
+			}
+			catch (const std::exception& E)
+			{
+				UE_LOG(LogTempoROS, Error, TEXT("Failed to publish on topic %s with error: %s"), *Topic, UTF8_TO_TCHAR(E.what()));
+				return false;
+			}
+		}
+		return true;
 	}
 	
 	template <typename MessageType>
-	void AddSubscription(const FString& Topic, const TROSSubscriptionDelegate<MessageType>& Callback, const FROSQOSProfile& QOSProfile=FROSQOSProfile())
+	bool AddSubscription(const FString& Topic, const TROSSubscriptionDelegate<MessageType>& Callback, const FROSQOSProfile& QOSProfile=FROSQOSProfile())
 	{
-		Subscriptions.FindOrAdd(Topic).Emplace(MakeUnique<TTempoROSSubscription<MessageType>>(Node, Topic, Callback, QOSProfile));
+		try
+		{
+			Subscriptions.FindOrAdd(Topic).Emplace(MakeUnique<TTempoROSSubscription<MessageType>>(Node, Topic, Callback, QOSProfile));
+		}
+		catch (const std::exception& E)
+		{
+			UE_LOG(LogTempoROS, Error, TEXT("Failed to create subscription for topic %s with error: %s"), *Topic, UTF8_TO_TCHAR(E.what()));
+			return false;
+		}
+		return true;
 	}
 
-	// Remove all subscriptions for a topic. TODO: Support removing individual subscriptions. 
+	// Remove all subscriptions for a topic. TODO: Support removing individual subscriptions.
 	UFUNCTION(BlueprintCallable)
 	void RemoveSubscriptions(const FString& Topic);
 
 	template <typename ServiceType>
-	void AddService(const FString& Name, const TROSServiceDelegate<ServiceType>& Callback)
+	bool AddService(const FString& Name, const TROSServiceDelegate<ServiceType>& Callback)
 	{
 		if (Services.Contains(Name))
 		{
 			UE_LOG(LogTempoROS, Error, TEXT("Node already has service with name %s"), *Name);
-			return;
+			return false;
 		}
 		try
 		{
 			 Services.Emplace(Name, MakeUnique<TTempoROSService<ServiceType>>(Node, Name, Callback));
 		}
-		catch (const std::exception& e)
+		catch (const std::exception& E)
 		{
-			UE_LOG(LogTempoROS, Error, TEXT("Failed to create service %s"), UTF8_TO_TCHAR(e.what()));
+			UE_LOG(LogTempoROS, Error, TEXT("Failed to create service with error: %s"), UTF8_TO_TCHAR(E.what()));
+			return false;
 		}
+		return true;
 	}
 
 	// Publish the "static" transform, which will be latched and provided to all new listeners, between the To and From
 	// frames at the specified time. Timestamp=0.0 (the default) means "now".
 	UFUNCTION(BlueprintCallable, BlueprintPure=false, meta=(AutoCreateRefTerm="FromFrame,Timestamp", HidePin="Timestamp"))
-	void PublishStaticTransform(const FTransform& Transform, const FString& ToFrame, const FString& FromFrame="", double Timestamp=0.0) const
+	bool PublishStaticTransform(const FTransform& Transform, const FString& ToFrame, const FString& FromFrame="", double Timestamp=0.0) const
 	{
 		FString FromFrameResolved = FromFrame;
 		if (FromFrameResolved.IsEmpty())
@@ -119,13 +159,22 @@ public:
 		{
 			TimestampResolved = GetWorld()->GetTimeSeconds();
 		}
-		StaticTFPublisher->PublishTransform(FStampedTransform(TimestampResolved, FromFrameResolved, ToFrame, Transform));
+		try
+		{
+			StaticTFPublisher->PublishTransform(FStampedTransform(TimestampResolved, FromFrameResolved, ToFrame, Transform));
+		}
+		catch (const std::exception& E)
+		{
+			UE_LOG(LogTempoROS, Error, TEXT("Failed to publish static transform with error: %s"), UTF8_TO_TCHAR(E.what()));
+			return false;
+		}
+		return true;
 	}
 
 	// Publish the "dynamic" transform, which will not be latched, between the To and From
 	// frames at the specified time. Timestamp=0.0 (the default) means "now".
 	UFUNCTION(BlueprintCallable, BlueprintPure=false, meta=(AutoCreateRefTerm="FromFrame,Timestamp", HidePin="Timestamp"))
-	void PublishDynamicTransform(const FTransform& Transform, const FString& ToFrame, const FString& FromFrame="", double Timestamp=0.0) const
+	bool PublishDynamicTransform(const FTransform& Transform, const FString& ToFrame, const FString& FromFrame="", double Timestamp=0.0) const
 	{
 		FString FromFrameResolved = FromFrame;
 		if (FromFrameResolved.IsEmpty())
@@ -137,29 +186,50 @@ public:
 		{
 			TimestampResolved = GetWorld()->GetTimeSeconds();
 		}
-		DynamicTFPublisher->PublishTransform(FStampedTransform(TimestampResolved, FromFrameResolved, ToFrame, Transform));
+		try
+		{
+			DynamicTFPublisher->PublishTransform(FStampedTransform(TimestampResolved, FromFrameResolved, ToFrame, Transform));
+		}
+		catch (const std::exception& E)
+		{
+			UE_LOG(LogTempoROS, Error, TEXT("Failed to publish dynamic transform with error: %s"), UTF8_TO_TCHAR(E.what()));
+			return false;
+		}
+		return true;
 	}
 
 	// Get the transform between the To and From frames at the specified time.
 	// Timestamp=0.0 (the default) gets the latest transform.
 	UFUNCTION(BlueprintCallable, meta=(AutoCreateRefTerm="FromFrame,Timestamp", HidePin="Timestamp"))
-	FTransform GetTransform(const FString& ToFrame, const FString& FromFrame="", double Timestamp=0.0) const
+	bool GetTransform(FTransform& Transform, const FString& ToFrame, const FString& FromFrame="", double Timestamp=0.0) const
 	{
 		FString FromFrameResolved = FromFrame;
 		if (FromFrameResolved.IsEmpty())
 		{
 			FromFrameResolved = GetDefault<UTempoROSSettings>()->GetFixedFrameName();
 		}
-		return TFListener->GetTransform(FromFrameResolved, ToFrame, Timestamp);
+		try
+		{
+			Transform = TFListener->GetTransform(FromFrameResolved, ToFrame, Timestamp);
+		}
+		catch (const std::exception& E)
+		{
+			UE_LOG(LogTempoROS, Error, TEXT("Failed to publish dynamic transform with error: %s"), UTF8_TO_TCHAR(E.what()));
+			return false;
+		}
+		return true;
 	}
 
 	UFUNCTION(BlueprintCallable)
 	void Tick(float DeltaTime) const;
 
+protected:
+	/* IPublisherSupportInterface */
+	template <typename T>
+	friend struct TTempoROSPublisher;
 	virtual const std::shared_ptr<rclcpp::Node>& GetNode() const override { return Node; }
 	virtual const std::unique_ptr<image_transport::ImageTransport>& GetImageTransport() const override { return ImageTransport; }
 
-private:
 	void Init(const FString& NodeName, const rclcpp::NodeOptions& NodeOptions, UWorld* TickWithWorld);
 
 	TMap<FString, TUniquePtr<FTempoROSPublisher>> Publishers;


### PR DESCRIPTION
rclcpp throws for unexpected conditions (for example, an malformed topic name). This adds try/catch blocks around rclcpp calls (creating publishers/subscriptions, publishing and subscribing to topics) in TempoROSNode's public API and return return statuses to propagate the error to the user. Also adds the return statuses to the auto-generated BP wrappers.