### PR TITLE
Add Support for Shared Memory Transport on Linux

### DIFF
--- a/Source/TempoROS/Private/TempoROS.cpp
+++ b/Source/TempoROS/Private/TempoROS.cpp
@@ -120,8 +120,21 @@ void FTempoROSModule::InitROS()
 		}
 	}
 
+#if PLATFORM_LINUX
 	// CYCLONEDDS_URI
-	SetEnvironmentVar(TEXT("CYCLONEDDS_URI"), *FString::Printf(TEXT("file://%s"), *TempoROSSettings->GetCycloneDDS_URI()));
+	const FString CycloneDDS_URI = TempoROSSettings->GetCycloneDDS_URI();
+	if (!CycloneDDS_URI.IsEmpty())
+	{
+		if (FPaths::FileExists(CycloneDDS_URI))
+		{
+			SetEnvironmentVar(TEXT("CYCLONEDDS_URI"), *FString::Printf(TEXT("file://%s"), *TempoROSSettings->GetCycloneDDS_URI()));
+		}
+		else
+		{
+			UE_LOG(LogTempoROS, Error, TEXT("Configured CycloneDDS URI file not found"), *CycloneDDS_URI);
+		}
+	}
+#endif
 
 	// ROS_DOMAIN_ID
 	SetEnvironmentVar(TEXT("ROS_DOMAIN_ID"), *FString::FromInt(TempoROSSettings->GetROSDomainID()));

--- a/Source/TempoROS/Private/TempoROSSettings.cpp
+++ b/Source/TempoROS/Private/TempoROSSettings.cpp
@@ -2,25 +2,54 @@
 
 #include "TempoROSSettings.h"
 
+#if WITH_EDITOR
+#include "ISettingsEditorModule.h"
+#endif
+
 #include "TempoROS.h"
+
+UTempoROSSettings::UTempoROSSettings()
+#if PLATFORM_MAC
+		: RMWImplementation(ERMWImplementation::CycloneDDS)
+#else
+		: RMWImplementation(ERMWImplementation::FastRTPS)
+#endif
+{
+	CategoryName = TEXT("Plugins");
+	SectionName = TEXT("Tempo ROS");
+}
 
 #if WITH_EDITOR
 void UTempoROSSettings::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
 {
 	Super::PostEditChangeProperty(PropertyChangedEvent);
-	
-	if (PropertyChangedEvent.Property->GetName() == GET_MEMBER_NAME_CHECKED(UTempoROSSettings, RMWImplementation))
+
+	if (PropertyChangedEvent.MemberProperty->GetName() == GET_MEMBER_NAME_CHECKED(UTempoROSSettings, RMWImplementation))
 	{
 #if PLATFORM_MAC
 		RMWImplementation = ERMWImplementation::CycloneDDS;
 		UE_LOG(LogTempoROS, Error, TEXT("CycloneDDS is the only supported RMW implementation on Mac"));
 #else
 		TempoROSSettingsChangedEvent.Broadcast();
+#if WITH_EDITOR
+		FModuleManager::GetModuleChecked<ISettingsEditorModule>("SettingsEditor").OnApplicationRestartRequired();
+#endif
 #endif
 	}
-	else if (PropertyChangedEvent.Property->GetName() == GET_MEMBER_NAME_CHECKED(UTempoROSSettings, ROSDomainID))
+	else if (PropertyChangedEvent.MemberProperty->GetName() == GET_MEMBER_NAME_CHECKED(UTempoROSSettings, CycloneDDS_URI) &&
+		RMWImplementation == ERMWImplementation::CycloneDDS)
 	{
 		TempoROSSettingsChangedEvent.Broadcast();
+#if WITH_EDITOR
+		FModuleManager::GetModuleChecked<ISettingsEditorModule>("SettingsEditor").OnApplicationRestartRequired();
+#endif
+	}
+	else if (PropertyChangedEvent.MemberProperty->GetName() == GET_MEMBER_NAME_CHECKED(UTempoROSSettings, ROSDomainID))
+	{
+		TempoROSSettingsChangedEvent.Broadcast();
+#if WITH_EDITOR
+		FModuleManager::GetModuleChecked<ISettingsEditorModule>("SettingsEditor").OnApplicationRestartRequired();
+#endif
 	}
 }
 #endif

--- a/Source/TempoROS/Public/TempoROSSettings.h
+++ b/Source/TempoROS/Public/TempoROSSettings.h
@@ -10,22 +10,20 @@
 
 DECLARE_MULTICAST_DELEGATE(FTempoROSSettingsChanged);
 
-UCLASS(Config=Game)
+/**
+ * TempoROS Plugin Settings.
+ */
+UCLASS(Config=Plugins, DefaultConfig, DisplayName="Tempo ROS")
 class TEMPOROS_API UTempoROSSettings : public UDeveloperSettings
 {
 	GENERATED_BODY()
 
 public:
-	UTempoROSSettings()
-#if PLATFORM_MAC
-		: RMWImplementation(ERMWImplementation::CycloneDDS)
-#else
-		: RMWImplementation(ERMWImplementation::FastRTPS)
-#endif
-	{}
+	UTempoROSSettings();
 
 	const FString& GetFixedFrameName() const { return FixedFrameName; }
 	ERMWImplementation GetRMWImplementation() const { return RMWImplementation; }
+	FString GetCycloneDDS_URI() const { return CycloneDDS_URI.FilePath; }
 	int32 GetROSDomainID() const { return ROSDomainID; }
 	FTempoROSSettingsChanged TempoROSSettingsChangedEvent;
 
@@ -34,12 +32,19 @@ public:
 #endif
 	
 private:
+	// The name of the special "fixed" coordinate name to which all ROS TF transforms are relative.
 	UPROPERTY(EditAnywhere, Config)
 	FString FixedFrameName = TEXT("map");
-	
-	UPROPERTY(EditAnywhere, Config, AdvancedDisplay, meta=(ClampMin=0, ClampMax=101, UIMin=0, UIMax=101))
+
+	// You can have multiple ROS domains on a single local network by providing a unique ID for each.
+	UPROPERTY(EditAnywhere, Config, meta=(ClampMin=0, ClampMax=101, UIMin=0, UIMax=101))
 	int32 ROSDomainID = 0;
-	
-	UPROPERTY(EditAnywhere, Config, AdvancedDisplay)
+
+	// The middleware implementation to use. Note that on Mac only CycloneDDS is supported.
+	UPROPERTY(EditAnywhere, Config)
 	ERMWImplementation RMWImplementation;
+
+	// Additional configuration for CycloneDDS middleware.
+	UPROPERTY(EditAnywhere, Config)
+	FFilePath CycloneDDS_URI;
 };

--- a/Source/TempoROS/TempoROS.Build.cs
+++ b/Source/TempoROS/TempoROS.Build.cs
@@ -34,7 +34,12 @@ public class TempoROS : ModuleRules
 		
 		if (Target.bBuildEditor)
 		{
-			PrivateDependencyModuleNames.Add("HotReload");
+			PrivateDependencyModuleNames.AddRange(
+				new string [] 
+			{
+				"HotReload",
+				"SettingsEditor"
+			});
 		}
 
 		// All modules that depend on rclcpp must enable exceptions.

--- a/Source/ThirdParty/ttp_manifest.json
+++ b/Source/ThirdParty/ttp_manifest.json
@@ -1,8 +1,8 @@
 {
   "artifact": "rclcpp",
-  "release": "v0.9",
+  "release": "v0.10",
   "md5_hashes": {
-    "Linux": "95cd6d87d8dc72fcb2ed306b738c3973",
+    "Linux": "41efb83e76d1e9defafe83b0177cc0e4",
     "Mac": "f87f6b16de4f8105dbfaeba66f7b78df",
     "Windows": "6fa93cebaeba1b053bd98c8a0ab3f539"
   }


### PR DESCRIPTION
Adds support for shared memory transport on Linux, via:
- Bumping to TTP v0.10, which adds iceoryx on Linux (only)
- Adding a new QOS option for shared memory, and restricting other options when it's set
- Setting CYCLONEDDS_URI env var to the configured setting, to tell cyclonedds to enable shared memory
- Adding logic to TempoROSPublisher to use the "borrow" API when shared memory is enabled (if shared memory is not enabled, for example when using a non-Linux platform or non-cyclonedds middleware, this will warn once and then continue as if shared memory were not enabled).
Also:
- Changing ROS-related env vars while the editor is running does not seem to work, even though we are calling rclcpp::shutdown and rclcpp::init afterwards. There must be some caching, but I'm not sure where yet. The editor must be restarted for them to take effect. Adds a user-prompt to restart the editor after changing these settings.
- Moves Tempo ROS settings to the plugins section, as we should do with other Tempo plugins
- Sets all ROS environment variables correctly on Windows, not just `AMENT_PREFIX_PATH`