### PR TITLE
Use More Robust Hashing Algorithm in SyncDeps

### DIFF
--- a/Scripts/SyncDeps.sh
+++ b/Scripts/SyncDeps.sh
@@ -53,14 +53,22 @@ fi
 
 if [[ "$OSTYPE" = "msys" ]]; then
   PLATFORM="Windows"
-  HASHER="md5sum"
 elif [[ "$OSTYPE" = "darwin"* ]]; then
   PLATFORM="Mac"
-  HASHER="md5"
 elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
   PLATFORM="Linux"
-  HASHER="md5sum"
 fi
+
+# This computes a hash on the filenames, sizes, and modification time of all the third party dependency files.
+GET_HASH() {
+  local ARTIFACT_DIR=$1
+  cd "$ARTIFACT_DIR"
+  if [[ "$OSTYPE" = "darwin"* ]]; then
+    find . -mindepth 2 -type f -not -name ".*" -not -path "*/__pycache__/*" -not -path "./Public/*" -not -path "./Private/*" -print0 | xargs -0 stat -f "%N%z%m" | sort | md5 | cut -d ' ' -f 1
+  else
+    find . -mindepth 2 -type f -not -name ".*" -not -path "*/__pycache__/*" -not -path "./Public/*" -not -path "./Private/*" -print0 | xargs -0 stat --format="%n%s%Y" | sort | md5sum | cut -d ' ' -f 1
+  fi
+}
 
 TEMP=$(mktemp -d)
 SYNC_THIRD_PARTY_DEPS () {
@@ -76,11 +84,7 @@ SYNC_THIRD_PARTY_DEPS () {
   if [ ! -d "$THIRD_PARTY_DIR/$ARTIFACT" ]; then
     read -r -p "Third party dependency $ARTIFACT not found in $THIRD_PARTY_DIR. Install? (y/N): " DO_UPDATE
   else
-    # This computes a hash on the filenames, sizes, and modification time of all the third party dependency files.
-    # shellcheck disable=SC2038
-    cd "$THIRD_PARTY_DIR/$ARTIFACT"
-    # awk extracts the size, date modified, and filename fields from the ls -l command
-    MEASURED_HASH=$(find . -mindepth 2 -type f -not -name ".*" -not -path "*/__pycache__/*" -not -path "./Public/*" -not -path "./Private/*" -print0 | xargs -0 ls -l | awk '{print $5 $6 $7 $8 $9}'| sort | "$HASHER" | cut -d ' ' -f 1)
+    MEASURED_HASH=$(GET_HASH "$THIRD_PARTY_DIR/$ARTIFACT")
     
     if [ "$FORCE_ARG" = "-force" ]; then
       DO_UPDATE="Y"
@@ -141,9 +145,7 @@ SYNC_THIRD_PARTY_DEPS () {
   # Pull the dependencies for the platform and, for Linux CC on Windows, for Linux too.
   PULL_DEPENDENCIES "$PLATFORM"
   
-  cd "$THIRD_PARTY_DIR/$ARTIFACT"
-  # awk extracts the size, date modified, and filename fields from the ls -l command
-  MEASURED_HASH=$(find . -mindepth 2 -type f -not -name ".*" -not -path "*/__pycache__/*" -not -path "./Public/*" -not -path "./Private/*" -print0 | xargs -0 ls -l | awk '{print $5 $6 $7 $8 $9}'| sort | "$HASHER" | cut -d ' ' -f 1)
+  MEASURED_HASH=$(GET_HASH "$THIRD_PARTY_DIR/$ARTIFACT")
   echo "New hash: $MEASURED_HASH"
 }
 

--- a/Source/ThirdParty/ttp_manifest.json
+++ b/Source/ThirdParty/ttp_manifest.json
@@ -3,7 +3,7 @@
   "release": "v0.10",
   "md5_hashes": {
     "Linux": "41efb83e76d1e9defafe83b0177cc0e4",
-    "Mac": "f87f6b16de4f8105dbfaeba66f7b78df",
+    "Mac": "bd277efa31aecc058d8ce44ec957f70a",
     "Windows": "6fa93cebaeba1b053bd98c8a0ab3f539"
   }
 }

--- a/Source/ThirdParty/ttp_manifest.json
+++ b/Source/ThirdParty/ttp_manifest.json
@@ -2,7 +2,7 @@
   "artifact": "rclcpp",
   "release": "v0.10",
   "md5_hashes": {
-    "Linux": "41efb83e76d1e9defafe83b0177cc0e4",
+    "Linux": "ee7bab12071baec1ac4a3f2aba283e20",
     "Mac": "bd277efa31aecc058d8ce44ec957f70a",
     "Windows": "6fa93cebaeba1b053bd98c8a0ab3f539"
   }

--- a/Source/ThirdParty/ttp_manifest.json
+++ b/Source/ThirdParty/ttp_manifest.json
@@ -4,6 +4,6 @@
   "md5_hashes": {
     "Linux": "ee7bab12071baec1ac4a3f2aba283e20",
     "Mac": "bd277efa31aecc058d8ce44ec957f70a",
-    "Windows": "6fa93cebaeba1b053bd98c8a0ab3f539"
+    "Windows": "a8f896756d43865659e2136494783618"
   }
 }


### PR DESCRIPTION
We noticed an unexpected issue with the hashing algorithm used to detect changes in Tempo's third party dependencies and prompt the user to re-download them. On Mac and Windows - but not Linux - the hashes appeared to be changing over time. That was because on those platforms `ls` formats dates differently depending on how far in the past they are. This switches SyncDeps.sh to use a more robust hashing algorithm, based on `stat` instead of `ls` and updates the hashes for all platforms accordingly.