### PR TITLE
Set Consistent Locale in SyncDeps

### DIFF
--- a/Scripts/SyncDeps.sh
+++ b/Scripts/SyncDeps.sh
@@ -6,6 +6,10 @@
 
 set -e
 
+# Set a consistent locale to ensure hashes computed below are consistent across environments.
+export LANG=C
+export LC_ALL=C
+
 # Check for jq
 if ! which jq &> /dev/null; then
   echo "Couldn't find jq"

--- a/Source/ThirdParty/ttp_manifest.json
+++ b/Source/ThirdParty/ttp_manifest.json
@@ -2,7 +2,7 @@
   "artifact": "rclcpp",
   "release": "v0.10",
   "md5_hashes": {
-    "Linux": "ee7bab12071baec1ac4a3f2aba283e20",
+    "Linux": "03001c60b5f27f714f7e109e0257ffdc",
     "Mac": "bd277efa31aecc058d8ce44ec957f70a",
     "Windows": "a8f896756d43865659e2136494783618"
   }


### PR DESCRIPTION
We observed an issue where the hash computed by SyncDeps was not consistent across environments, and the root cause was an inconsistent locale. This sets the locale consistently before running the SyncDeps script, which makes the hashes consistent.

Also updates the Linux hash, where the new locale results in a new hash. It does not seem to affect the hash on Mac, and the hash on Windows was computed with this locale.