### PR TITLE
Fix Incorrect Dereference Bug in SetEnvironmentVar on Windows

### DIFF
--- a/Source/TempoROS/Private/TempoROS.cpp
+++ b/Source/TempoROS/Private/TempoROS.cpp
@@ -18,7 +18,7 @@ void SetEnvironmentVar(const TCHAR* VariableName, const TCHAR* Value)
 {
 #if PLATFORM_WINDOWS
 	// On Windows only, SetEnvironmentVar does not seem to work properly, but this does.
-	_putenv_s(TCHAR_TO_UTF8(*VariableName), TCHAR_TO_UTF8(*Value));
+	_putenv_s(TCHAR_TO_UTF8(VariableName), TCHAR_TO_UTF8(Value));
 #else
 	FPlatformMisc::SetEnvironmentVar(VariableName, Value);
 #endif


### PR DESCRIPTION
https://github.com/tempo-sim/TempoROS/pull/20 introduced a bug on Windows. `VariableName` and `Value` are already `TCHAR*`s, they should not be dereferenced.