### PR TITLE
Handle Failed Node Initialization in TempoROSNode

### DIFF
--- a/Source/TempoROS/Private/TempoROSNode.cpp
+++ b/Source/TempoROS/Private/TempoROSNode.cpp
@@ -29,6 +29,8 @@ UTempoROSNode* UTempoROSNode::Create(const FString& NodeName, UObject* Outer, bo
 	catch (const std::exception& Exception)
 	{
 		UE_LOG(LogTempoROS, Error, TEXT("Failed to initialize node. Error: %s"), UTF8_TO_TCHAR(Exception.what()));
+		NewNode->BeginDestroy();
+		return nullptr;
 	}
 	return NewNode;
 }


### PR DESCRIPTION
Currently when Node initialization fails we return an invalid node, which leads to confusing errors later. Instead return nullptr, leaving it up to the user to handle.