### PR TITLE
Fix Catch 22 in SyncDeps

### DIFF
--- a/Scripts/SyncDeps.sh
+++ b/Scripts/SyncDeps.sh
@@ -50,8 +50,8 @@ UPROJECT_FILE=$(FIND_UPROJECT "$TEMPOROS_ROOT")
 TEMPOROS_ENABLED=$(jq '.Plugins[] | select(.Name=="TempoROS") | .Enabled' "$UPROJECT_FILE")
 # Remove any trailing carriage return character
 TEMPOROS_ENABLED="${TEMPOROS_ENABLED%$'\r'}"
-if [ "$TEMPOROS_ENABLED" != "true" ]; then
-  echo -e "Skipping check of TempoROS ThirdParty dependencies because TempoROS plugin is not enabled in $(basename "$UPROJECT_FILE")"
+if [ "$TEMPOROS_ENABLED" = "false" ]; then
+  echo -e "Skipping check of TempoROS ThirdParty dependencies because TempoROS plugin is disabled in $(basename "$UPROJECT_FILE")"
   exit 0
 fi
 
@@ -88,6 +88,10 @@ SYNC_THIRD_PARTY_DEPS () {
   if [ ! -d "$THIRD_PARTY_DIR/$ARTIFACT" ]; then
     read -r -p "Third party dependency $ARTIFACT not found in $THIRD_PARTY_DIR. Install? (y/N): " DO_UPDATE
   else
+    echo "Verifying contents of third party dependency $ARTIFACT"
+    if [[ "$OSTYPE" = "msys" ]]; then
+      echo "On Windows this can take a while. Please be patient."
+    fi
     MEASURED_HASH=$(GET_HASH "$THIRD_PARTY_DIR/$ARTIFACT")
     
     if [ "$FORCE_ARG" = "-force" ]; then
@@ -149,6 +153,10 @@ SYNC_THIRD_PARTY_DEPS () {
   # Pull the dependencies for the platform and, for Linux CC on Windows, for Linux too.
   PULL_DEPENDENCIES "$PLATFORM"
   
+  echo "Verifying contents of third party dependency $ARTIFACT"
+  if [[ "$OSTYPE" = "msys" ]]; then
+    echo "On Windows this can take a while. Please be patient."
+  fi
   MEASURED_HASH=$(GET_HASH "$THIRD_PARTY_DIR/$ARTIFACT")
   echo "New hash: $MEASURED_HASH"
 }


### PR DESCRIPTION
There is a "Catch 22" in SyncDeps.sh: If the user does not have TempoROS enabled in their uproject, they cannot download the dependencies. But the user also cannot build the project (in order to run the Editor to enable the plugins) without downloading dependencies. The only way to resolve this currently is to manually edit the uproject file.

We can resolve this by changing the condition to refuse to download the dependencies. Previously we would only download if TempoROS was explicitly enabled. Now, we download if it is not explicitly disabled.

Also adds a message that we're verifying dependencies while calculating the hash, and warns that on Windows it will take a while.