### PR TITLE
Add 5.5 Support

### DIFF
--- a/Scripts/GenROSIDL.sh
+++ b/Scripts/GenROSIDL.sh
@@ -360,6 +360,12 @@ elif [[ "$OSTYPE" = "msys" ]]; then
 fi
 set -e
 
+# Get engine release (e.g. 5.4)
+if [ -f "$UNREAL_ENGINE_PATH/Engine/Intermediate/Build/BuildRules/UE5RulesManifest.json" ]; then
+  RELEASE_WITH_HOTFIX=$(jq -r '.EngineVersion' "$UNREAL_ENGINE_PATH/Engine/Intermediate/Build/BuildRules/UE5RulesManifest.json")
+  RELEASE="${RELEASE_WITH_HOTFIX%.*}"
+fi
+
 # Find dotnet
 cd "$ENGINE_DIR"
 if [[ "$OSTYPE" = "msys" ]]; then
@@ -373,7 +379,18 @@ elif [[ "$OSTYPE" = "darwin"* ]]; then
     DOTNET=$(echo "${DOTNETS[@]}" | grep -E "mac-x64/dotnet")
   fi
 elif [[ "$OSTYPE" = "linux-gnu"* ]]; then
-  DOTNET=$(find ./Binaries/ThirdParty/DotNet -type f -name dotnet)
+  DOTNETS=$(find ./Binaries/ThirdParty/DotNet -type f -name dotnet)
+  if [[ "$RELEASE" == "5.4" ]]; then
+    # In UE 5.4 there is only one dotnet on Linux. 5.5 added arm64 support.
+    DOTNET="$DOTNETS"
+  else
+    ARCH=$(arch)
+    if [[ "$ARCH" = "arm64" ]]; then
+      DOTNET=$(echo "${DOTNETS[@]}" | grep -E "linux-arm64/dotnet")
+    elif [[ "$ARCH" = "x86_64" ]]; then
+      DOTNET=$(echo "${DOTNETS[@]}" | grep -E "linux-x64/dotnet")
+    fi
+  fi
 fi
 
 if [ -z ${DOTNET+x} ]; then

--- a/Scripts/TempoROS.Automation.csproj
+++ b/Scripts/TempoROS.Automation.csproj
@@ -1,8 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(UNREAL_ENGINE_PATH)\Engine\Source\Programs\Shared\UnrealEngine.csproj.props" />
-  
-  <PropertyGroup>
+
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(BundledNETCoreAppTargetFrameworkVersion)' >= '8.0'">
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(BundledNETCoreAppTargetFrameworkVersion)' &lt; '8.0'">
     <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Development</Configuration>
     <OutputType>Library</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
Two changes:
- 5.5 added support for arm64 Linux, so we need to find the correct dotnet
- 5.5 upgraded to .Net 8.0 (from 6.0), so need to use the correct one in TempoROS.Automation.csproj