### PR TITLE
Change to Directory Before Calling Bash Prebuild Step

### DIFF
--- a/Scripts/PreBuild.bat
+++ b/Scripts/PreBuild.bat
@@ -11,9 +11,10 @@ if defined TEMPO_SKIP_PREBUILD (
 )
 
 REM Simply call the individual scripts from the same directory
-bash %~dp0GenROSIDL.sh %*
+cd /d %~dp0
+bash ./GenROSIDL.sh %*
 if %errorlevel% neq 0 exit /b %errorlevel%
-bash %~dp0GenROSBP.sh %3
+bash ./GenROSBP.sh %3
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 exit /b 0


### PR DESCRIPTION
A user reported an issue where the paths to the bash scripts called from PreBuild.bat appear to be incorrect. This attempts to fix by changing to the directory before calling them.