### PR TITLE
Remove CRTP from the converter base in favor of direct To/From params

### DIFF
--- a/Source/TempoROS/Public/TempoROSCommonConverters.h
+++ b/Source/TempoROS/Public/TempoROSCommonConverters.h
@@ -18,7 +18,7 @@ DEFINE_TEMPOROS_MESSAGE_TYPE_TRAITS(FTransform)
 DEFINE_TEMPOROS_MESSAGE_TYPE_TRAITS(FTwist)
 
 template <>
-struct TToROSConverter<std::string, FString> : TConverter<TToROSConverter<std::string, FString>>
+struct TToROSConverter<std::string, FString> : TConverter<std::string, FString>
 {
 	static std::string Convert(const FString& FromValue)
 	{
@@ -27,7 +27,7 @@ struct TToROSConverter<std::string, FString> : TConverter<TToROSConverter<std::s
 };
 
 template <>
-struct TFromROSConverter<std::string, FString> : TConverter<TFromROSConverter<std::string, FString>>
+struct TFromROSConverter<std::string, FString> : TConverter<FString, std::string>
 {
 	static FString Convert(const std::string& FromValue)
 	{
@@ -56,7 +56,7 @@ struct TImplicitFromROSConverter<FString> : TFromROSConverter<std_msgs::msg::Str
 };
 
 template <>
-struct TToROSConverter<builtin_interfaces::msg::Time, double> : TConverter<TToROSConverter<builtin_interfaces::msg::Time, double>>
+struct TToROSConverter<builtin_interfaces::msg::Time, double> : TConverter<builtin_interfaces::msg::Time, double>
 {
 	static builtin_interfaces::msg::Time Convert(double FromValue)
 	{
@@ -68,7 +68,7 @@ struct TToROSConverter<builtin_interfaces::msg::Time, double> : TConverter<TToRO
 };
 
 template <>
-struct TFromROSConverter<builtin_interfaces::msg::Time, double> : TConverter<TFromROSConverter<builtin_interfaces::msg::Time, double>>
+struct TFromROSConverter<builtin_interfaces::msg::Time, double> : TConverter<double, builtin_interfaces::msg::Time>
 {
 	static double Convert(builtin_interfaces::msg::Time FromValue)
 	{
@@ -116,7 +116,7 @@ struct TImplicitFromROSConverter<FVector> : TFromROSConverter<geometry_msgs::msg
 // https://gamedev.stackexchange.com/questions/157946/converting-a-quaternion-in-a-right-to-left-handed-coordinate-system
 
 template <>
-struct TToROSConverter<geometry_msgs::msg::Quaternion, FQuat> : TConverter<TToROSConverter<geometry_msgs::msg::Quaternion, FQuat>>
+struct TToROSConverter<geometry_msgs::msg::Quaternion, FQuat> : TConverter<geometry_msgs::msg::Quaternion, FQuat>
 {
 	static geometry_msgs::msg::Quaternion Convert(const FQuat& TempoValue)
 	{
@@ -130,7 +130,7 @@ struct TToROSConverter<geometry_msgs::msg::Quaternion, FQuat> : TConverter<TToRO
 };
 
 template <>
-struct TFromROSConverter<geometry_msgs::msg::Quaternion, FQuat> : TConverter<TFromROSConverter<geometry_msgs::msg::Quaternion, FQuat>>
+struct TFromROSConverter<geometry_msgs::msg::Quaternion, FQuat> : TConverter<FQuat, geometry_msgs::msg::Quaternion>
 {
 	static FQuat Convert(const geometry_msgs::msg::Quaternion& ROSValue)
 	{

--- a/Source/TempoROS/Public/TempoROSConversion.h
+++ b/Source/TempoROS/Public/TempoROSConversion.h
@@ -14,29 +14,25 @@ FName TMessageTypeTraits<MessageType>::MessageTypeDescriptor = FName(NAME_None);
 #define DEFINE_TEMPOROS_MESSAGE_TYPE_TRAITS(MessageType) \
 template <> inline FName TMessageTypeTraits<MessageType>::MessageTypeDescriptor = FName(#MessageType);
 
-template <typename T>
+// Base class for all converters. Parameterized directly on the To/From types so that the default
+// (identity) Convert can be declared without ever needing the derived type. Specializations provide
+// their own static Convert, which hides this default.
+template <typename ToT, typename FromT>
 struct TConverter
 {
-	// From kennytm's answer here: https://stackoverflow.com/questions/8113878/c-crtp-and-accessing-deriveds-nested-typedefs-from-base
-	template <typename X = T>
-	using ToType = typename X::ToType;
+	using ToType = ToT;
+	using FromType = FromT;
 
-	template <typename X = T>
-	using FromType = typename X::FromType;
-
-	template <typename X = T>
-	static typename X::ToType Convert(const typename X::FromType& FromValue)
+	static ToType Convert(const FromType& FromValue)
 	{
-		static_assert(std::is_same_v<typename X::ToType, typename X::FromType>, "No specialization found to convert these types");
+		static_assert(std::is_same_v<ToType, FromType>, "No specialization found to convert these types");
 		return FromValue;
 	}
 };
 
 template <typename ROSType, typename TempoType>
-struct TToROSConverter : TConverter<TToROSConverter<ROSType, TempoType>>
+struct TToROSConverter : TConverter<ROSType, TempoType>
 {
-	using ToType = ROSType;
-	using FromType = TempoType;
 };
 
 template <typename T>
@@ -46,10 +42,8 @@ struct TImplicitToROSConverter : TToROSConverter<T, T>
 };
 
 template <typename ROSType, typename TempoType>
-struct TFromROSConverter : TConverter<TFromROSConverter<ROSType, TempoType>>
+struct TFromROSConverter : TConverter<TempoType, ROSType>
 {
-	using ToType = TempoType;
-	using FromType = ROSType;
 };
 
 template <typename T>


### PR DESCRIPTION
TConverter was a CRTP base (parameterized on the derived converter) whose only job was to read the derived class's ToType/FromType so it could declare a default identity Convert. Because the base is instantiated while the derived type is still incomplete, this required the template<X = T> deferred-typedef workaround (the kennytm StackOverflow trick referenced in the comment).

CRTP is unnecessary here: the base never dispatches into derived behavior, it only needs the two types. Parameterize TConverter directly on <To, From> and the incomplete-type problem and the deferred-alias gymnastics both disappear. TToROSConverter/TFromROSConverter just instantiate it with the types in the right order; specializations still provide their own Convert, which hides the default.

As a side benefit, the full specializations (e.g. TToROSConverter<std::string, FString>) now derive a base with well-defined ToType/FromType instead of the previously circular (but never-instantiated) inherited aliases.

No behavioral change: the user-facing converter specializations and all call sites are untouched.