### PR TITLE
Route rclcpp allocations via std::pmr default resource instead of per-site plumbing

### DIFF
--- a/Source/TempoROS/Private/TempoROS.cpp
+++ b/Source/TempoROS/Private/TempoROS.cpp
@@ -2,6 +2,7 @@
 
 #include "TempoROS.h"
 
+#include "TempoROSAllocator.h"
 #include "TempoROSSettings.h"
 
 #if WITH_EDITOR
@@ -73,6 +74,9 @@ void SetAmentPrefixPath()
 
 void FTempoROSModule::StartupModule()
 {
+	// Route rclcpp's default std::pmr allocations through Unreal's allocator before anything in rclcpp runs.
+	SetUnrealDefaultMemoryResource();
+
 	SetAmentPrefixPath();
 
 	InitROS();

--- a/Source/TempoROS/Public/TempoROSAllocator.h
+++ b/Source/TempoROS/Public/TempoROSAllocator.h
@@ -14,6 +14,7 @@ namespace std::pmr
 	template <class _ValueT>
 	using polymorphic_allocator = std::experimental::pmr::polymorphic_allocator<_ValueT>;
 	using memory_resource = std::experimental::pmr::memory_resource;
+	using std::experimental::pmr::set_default_resource;
 }
 #else
 #include <memory_resource>
@@ -75,4 +76,14 @@ private:
 inline std::shared_ptr<std::pmr::polymorphic_allocator<void>> GetPolymorphicUnrealAllocator()
 {
 	return std::make_shared<std::pmr::polymorphic_allocator<void>>(&UnrealMemoryResource::Instance);
+}
+
+// Make UnrealMemoryResource the process-wide default for std::pmr. Because rclcpp's default allocator
+// type is std::pmr::polymorphic_allocator<void> (see TempoThirdParty patches), every allocator rclcpp
+// default-constructs internally then routes through FMemory, without TempoROS having to thread an
+// allocator into every publisher/subscription/memory-strategy explicitly. Call once at startup, before
+// any rclcpp allocation occurs.
+inline void SetUnrealDefaultMemoryResource()
+{
+	std::pmr::set_default_resource(&UnrealMemoryResource::Instance);
 }

--- a/Source/TempoROS/Public/TempoROSPublisher.h
+++ b/Source/TempoROS/Public/TempoROSPublisher.h
@@ -21,8 +21,9 @@ namespace std::pmr
 
 inline rclcpp::PublisherOptions TempoROSPublisherOptions()
 {
-	rclcpp::PublisherOptionsWithAllocator<std::pmr::polymorphic_allocator<void>> PublisherOptions;
-	PublisherOptions.allocator = GetPolymorphicUnrealAllocator();
+	// rclcpp::PublisherOptions defaults its allocator type to std::pmr::polymorphic_allocator<void>,
+	// which picks up the default memory resource set in SetUnrealDefaultMemoryResource() at startup.
+	rclcpp::PublisherOptions PublisherOptions;
 	PublisherOptions.use_default_callbacks = false;
 	return PublisherOptions;
 }

--- a/Source/TempoROS/Public/TempoROSSubscription.h
+++ b/Source/TempoROS/Public/TempoROSSubscription.h
@@ -15,19 +15,14 @@ namespace std::pmr
 }
 #endif
 
-inline rclcpp::SubscriptionOptions TempoROSSubscriptionOptions(const std::shared_ptr<std::pmr::polymorphic_allocator<void>>& Allocator)
+inline rclcpp::SubscriptionOptions TempoROSSubscriptionOptions()
 {
-	rclcpp::SubscriptionOptionsWithAllocator<std::pmr::polymorphic_allocator<void>> SubscriptionOptions;
-	SubscriptionOptions.allocator = Allocator;
+	// rclcpp::SubscriptionOptions defaults its allocator type to std::pmr::polymorphic_allocator<void>,
+	// which picks up the default memory resource set in SetUnrealDefaultMemoryResource() at startup. The
+	// default message memory strategy likewise default-constructs its allocator from that resource.
+	rclcpp::SubscriptionOptions SubscriptionOptions;
 	SubscriptionOptions.use_default_callbacks = false;
 	return SubscriptionOptions;
-}
-
-template <typename ROSMessageType>
-inline std::shared_ptr<rclcpp::message_memory_strategy::MessageMemoryStrategy<ROSMessageType>>
-TempoROSSubscriptionMemoryStrategy(const std::shared_ptr<std::pmr::polymorphic_allocator<void>>& Allocator)
-{
-	return std::make_shared<rclcpp::message_memory_strategy::MessageMemoryStrategy<ROSMessageType>>(Allocator);
 }
 
 template <class MessageType>
@@ -45,7 +40,6 @@ struct TTempoROSSubscription : FTempoROSSubscription
 
 	TTempoROSSubscription(const std::shared_ptr<rclcpp::Node>& Node, const FString& Topic, const TROSSubscriptionDelegate<MessageType>& Callback, const FROSQOSProfile& QOSProfile)
 	{
-		std::shared_ptr<std::pmr::polymorphic_allocator<void>> Allocator = GetPolymorphicUnrealAllocator();
 		Subscription = Node->create_subscription<ROSMessageType>(
 			TCHAR_TO_UTF8(*Topic),
 			QOSProfile.ToROS(),
@@ -53,8 +47,7 @@ struct TTempoROSSubscription : FTempoROSSubscription
 			{
 			  Callback.ExecuteIfBound(TImplicitFromROSConverter<MessageType>::Convert(Message));
 			},
-			TempoROSSubscriptionOptions(Allocator),
-			TempoROSSubscriptionMemoryStrategy<ROSMessageType>(Allocator)
+			TempoROSSubscriptionOptions()
 		);
 	}
 

--- a/Source/TempoROS/Public/TempoTF.h
+++ b/Source/TempoROS/Public/TempoTF.h
@@ -81,7 +81,7 @@ struct FTempoTFListener
 {
 	static rclcpp::SubscriptionOptions SubOptions()
 	{
-		rclcpp::SubscriptionOptions Options = TempoROSSubscriptionOptions(GetPolymorphicUnrealAllocator());
+		rclcpp::SubscriptionOptions Options = TempoROSSubscriptionOptions();
 		Options.qos_overriding_options = rclcpp::QosOverridingOptions{
 			rclcpp::QosPolicyKind::Depth,
 			rclcpp::QosPolicyKind::Durability,
@@ -92,7 +92,7 @@ struct FTempoTFListener
 
 	static rclcpp::SubscriptionOptions StaticSubOptions()
 	{
-		rclcpp::SubscriptionOptions Options = TempoROSSubscriptionOptions(GetPolymorphicUnrealAllocator());
+		rclcpp::SubscriptionOptions Options = TempoROSSubscriptionOptions();
 		Options.qos_overriding_options = rclcpp::QosOverridingOptions{
 			rclcpp::QosPolicyKind::Depth,
 			rclcpp::QosPolicyKind::History,


### PR DESCRIPTION
rclcpp's default allocator type is already std::pmr::polymorphic_allocator<void> everywhere (via the TempoThirdParty patches). A default-constructed allocator of that type uses std::pmr::get_default_resource(), so setting the process-wide default resource to UnrealMemoryResource once at startup makes every allocator rclcpp default-constructs internally route through FMemory.

This subsumes the previous approach of explicitly threading GetPolymorphicUnrealAllocator() into each publisher/subscription/memory-strategy:
- Add SetUnrealDefaultMemoryResource(), called once in StartupModule before any rclcpp allocation.
- Drop the explicit allocator from publisher and subscription options and the explicit message memory strategy; the defaults now resolve to FMemory.
- Update the tf2 subscription option helpers accordingly.

This is also strictly more complete than before: internal rclcpp allocations that default-constructed their allocator previously fell back to the system heap even with the per-site plumbing, because that plumbing only covered the message payload. Now they route through FMemory too.

No TempoThirdParty change was required — the existing default-type unification is what makes the single set_default_resource call sufficient. The C-level NodeOptions(GetUnrealAllocator()) seam is unrelated to std::pmr and is unchanged.